### PR TITLE
Add Button and Label Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,14 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+#From  Swift Package manager Template
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI.xcodeproj/project.pbxproj
+++ b/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI.xcodeproj/project.pbxproj
@@ -1,0 +1,385 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		E345E33329C483FB00B239FE /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E345E33229C483FB00B239FE /* Preview Assets.xcassets */; };
+		E345E33529C484DC00B239FE /* Buttons.swift in Sources */ = {isa = PBXBuildFile; fileRef = E345E33429C484DC00B239FE /* Buttons.swift */; };
+		E345E33729C5931D00B239FE /* TextLabels.swift in Sources */ = {isa = PBXBuildFile; fileRef = E345E33629C5931D00B239FE /* TextLabels.swift */; };
+		E376041E29C459EA000D28DC /* Example_Nitrozen_SwiftUIApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E376041D29C459EA000D28DC /* Example_Nitrozen_SwiftUIApp.swift */; };
+		E376042229C459EB000D28DC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E376042129C459EB000D28DC /* Assets.xcassets */; };
+		E376043029C45ACE000D28DC /* ElementsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E376042F29C45ACE000D28DC /* ElementsListView.swift */; };
+		E3C240C829C468E40090F59A /* Nitrozen-SwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = E3C240C729C468E40090F59A /* Nitrozen-SwiftUI */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		E345E33229C483FB00B239FE /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		E345E33429C484DC00B239FE /* Buttons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Buttons.swift; sourceTree = "<group>"; };
+		E345E33629C5931D00B239FE /* TextLabels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLabels.swift; sourceTree = "<group>"; };
+		E376041A29C459EA000D28DC /* Example-Nitrozen-SwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example-Nitrozen-SwiftUI.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E376041D29C459EA000D28DC /* Example_Nitrozen_SwiftUIApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Example_Nitrozen_SwiftUIApp.swift; sourceTree = "<group>"; };
+		E376042129C459EB000D28DC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		E376042F29C45ACE000D28DC /* ElementsListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElementsListView.swift; sourceTree = "<group>"; };
+		E376043329C460DF000D28DC /* Nitrozen-SwiftUI */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "Nitrozen-SwiftUI"; path = ../..; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		E376041729C459EA000D28DC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E3C240C829C468E40090F59A /* Nitrozen-SwiftUI in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		E33DD32C29C4810F0061E31E /* Example-Code */ = {
+			isa = PBXGroup;
+			children = (
+				E376041D29C459EA000D28DC /* Example_Nitrozen_SwiftUIApp.swift */,
+				E376042F29C45ACE000D28DC /* ElementsListView.swift */,
+				E345E33429C484DC00B239FE /* Buttons.swift */,
+				E345E33629C5931D00B239FE /* TextLabels.swift */,
+				E376042129C459EB000D28DC /* Assets.xcassets */,
+			);
+			path = "Example-Code";
+			sourceTree = "<group>";
+		};
+		E345E33129C483FB00B239FE /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				E345E33229C483FB00B239FE /* Preview Assets.xcassets */,
+			);
+			name = "Preview Content";
+			path = "Example-Nitrozen-SwiftUI/Preview Content";
+			sourceTree = "<group>";
+		};
+		E376041129C459EA000D28DC = {
+			isa = PBXGroup;
+			children = (
+				E376041C29C459EA000D28DC /* Example-Nitrozen-SwiftUI */,
+				E345E33129C483FB00B239FE /* Preview Content */,
+				E376041B29C459EA000D28DC /* Products */,
+				E3C240C629C468E40090F59A /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		E376041B29C459EA000D28DC /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E376041A29C459EA000D28DC /* Example-Nitrozen-SwiftUI.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E376041C29C459EA000D28DC /* Example-Nitrozen-SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				E376043329C460DF000D28DC /* Nitrozen-SwiftUI */,
+				E33DD32C29C4810F0061E31E /* Example-Code */,
+			);
+			path = "Example-Nitrozen-SwiftUI";
+			sourceTree = "<group>";
+		};
+		E3C240C629C468E40090F59A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E376041929C459EA000D28DC /* Example-Nitrozen-SwiftUI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E376042829C459EB000D28DC /* Build configuration list for PBXNativeTarget "Example-Nitrozen-SwiftUI" */;
+			buildPhases = (
+				E376041629C459EA000D28DC /* Sources */,
+				E376041729C459EA000D28DC /* Frameworks */,
+				E376041829C459EA000D28DC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Example-Nitrozen-SwiftUI";
+			packageProductDependencies = (
+				E3C240C729C468E40090F59A /* Nitrozen-SwiftUI */,
+			);
+			productName = "Example-Nitrozen-SwiftUI";
+			productReference = E376041A29C459EA000D28DC /* Example-Nitrozen-SwiftUI.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E376041229C459EA000D28DC /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1410;
+				LastUpgradeCheck = 1410;
+				TargetAttributes = {
+					E376041929C459EA000D28DC = {
+						CreatedOnToolsVersion = 14.1;
+					};
+				};
+			};
+			buildConfigurationList = E376041529C459EA000D28DC /* Build configuration list for PBXProject "Example-Nitrozen-SwiftUI" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = E376041129C459EA000D28DC;
+			productRefGroup = E376041B29C459EA000D28DC /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E376041929C459EA000D28DC /* Example-Nitrozen-SwiftUI */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		E376041829C459EA000D28DC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E345E33329C483FB00B239FE /* Preview Assets.xcassets in Resources */,
+				E376042229C459EB000D28DC /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E376041629C459EA000D28DC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E345E33529C484DC00B239FE /* Buttons.swift in Sources */,
+				E376043029C45ACE000D28DC /* ElementsListView.swift in Sources */,
+				E376041E29C459EA000D28DC /* Example_Nitrozen_SwiftUIApp.swift in Sources */,
+				E345E33729C5931D00B239FE /* TextLabels.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		E376042629C459EB000D28DC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		E376042729C459EB000D28DC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		E376042929C459EB000D28DC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Example-Nitrozen-SwiftUI/Preview Content\"";
+				DEVELOPMENT_TEAM = YLR46LW837;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "example.Example-Nitrozen-SwiftUI";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E376042A29C459EB000D28DC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Example-Nitrozen-SwiftUI/Preview Content\"";
+				DEVELOPMENT_TEAM = YLR46LW837;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "example.Example-Nitrozen-SwiftUI";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		E376041529C459EA000D28DC /* Build configuration list for PBXProject "Example-Nitrozen-SwiftUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E376042629C459EB000D28DC /* Debug */,
+				E376042729C459EB000D28DC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E376042829C459EB000D28DC /* Build configuration list for PBXNativeTarget "Example-Nitrozen-SwiftUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E376042929C459EB000D28DC /* Debug */,
+				E376042A29C459EB000D28DC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		E3C240C729C468E40090F59A /* Nitrozen-SwiftUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = "Nitrozen-SwiftUI";
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = E376041229C459EA000D28DC /* Project object */;
+}

--- a/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "activityindicatorview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/exyte/ActivityIndicatorView.git",
+      "state" : {
+        "revision" : "9970fd0bb7a05dad0b6566ae1f56937716686b24",
+        "version" : "1.1.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI/Example-Code/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI/Example-Code/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI/Example-Code/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI/Example-Code/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI/Example-Code/Assets.xcassets/Contents.json
+++ b/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI/Example-Code/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI/Example-Code/Buttons.swift
+++ b/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI/Example-Code/Buttons.swift
@@ -1,0 +1,237 @@
+//
+//  Buttons.swift
+//  Example-Nitrozen-SwiftUI
+//
+//  Created by Hitendra Solanki on 17/03/23.
+//
+
+import SwiftUI
+import Nitrozen_SwiftUI
+
+struct Buttons: View {
+	
+	enum ButtonUseCase { case primary, bordered, tertiary }
+	
+	@State var isButtonEnabled: Bool = false
+	@State var isButtonLoading: Bool = false
+	
+	@ViewBuilder func primaryButtons() -> some View {
+		Section {
+				
+			Text("Primary Buttons")
+//				.largeTitle(weight: .bold)
+			
+			VStack {
+				Text("Enabled Button")
+//					.secondaryTitle(weight: .regular)
+				Button(action: {}) {
+					Text("Click me")
+						.frame(maxWidth: .infinity)
+				}
+				.primaryButton()
+			}
+			
+			VStack{
+				Text("Disabled Button")
+//					.secondaryTitle(weight: .regular)
+				Button(action: {}) {
+					Text("Click me")
+						.frame(maxWidth: .infinity)
+				}
+				.disabled(true)
+				.primaryButton()
+			}
+		}
+		
+		Section {
+			Text("Toggle State")
+			VStack {
+				HStack{
+					Text("Enable/Disable")
+					//						.secondaryTitle(weight: .regular)
+					Toggle("", isOn: $isButtonEnabled)
+				}
+				
+				Button(action: {}) {
+					Text("Click me")
+						.frame(maxWidth: .infinity)
+				}
+				.disabled(isButtonEnabled)
+				.primaryButton()
+				
+			}
+			
+			
+			VStack {
+				HStack{
+					Text("Loading")
+					//						.secondaryTitle(weight: .regular)
+					Toggle("", isOn: $isButtonLoading)
+				}
+				
+				Button(action: {}) {
+					Text("Click me")
+						.frame(maxWidth: .infinity)
+				}
+				.primaryButton(isLoading: $isButtonLoading)
+				
+			}
+			
+		}
+		
+		Section {
+			Text("Dynamic and Fix sizes")
+			
+			Text("Width  max = .infinity")
+			//				.secondaryTitle(weight: .regular)
+			Button(action: {}) {
+				Text("Click me")
+					.frame(maxWidth: .infinity)
+			}
+			.primaryButton()
+			
+			
+			VStack{
+				Text("Width and Height = dynamic, depends on title")
+				//					.secondaryTitle(weight: .regular)
+				
+				Button(action: {}) {
+					Text("M Tap Tap Tap W")
+				}
+				.primaryButton()
+				
+				Button(action: {}) {
+					Text("Click me, this is long title content button, Click me, ")
+						.padding(.horizontal)
+						.padding(.horizontal)
+				}
+				.primaryButton()
+			}
+			
+			Text("Fix height = 60, width = 150")
+			//				.secondaryTitle(weight: .regular)
+			
+			Button(action: {}) {
+				Text("Click me")
+					.frame(width: 150, height: 60)
+			}
+			.primaryButton()
+		}
+		
+		Section {
+			
+			Text("Image and Title Buttons ")
+//				.largeTitle(weight: .bold)
+			
+			Text("With image")
+//				.secondaryTitle(weight: .regular)
+			Button(action: {}) {
+				HStack{
+					Image(systemName: "paperplane.fill")
+					Text("Click me")
+				}
+			}
+			.primaryButton()
+			
+			Text("Disable with image")
+//				.secondaryTitle(weight: .regular)
+			Button(action: {}) {
+				HStack{
+					Image(systemName: "paperplane.fill")
+					Text("Click me")
+				}
+			}
+			.disabled(true)
+			.primaryButton()
+			
+			Text("With only image")
+//				.secondaryTitle(weight: .regular)
+			Button(action: {}) {
+				Image(systemName: "paperplane.fill")
+			}
+			.primaryButton(shape: .circle)
+		}
+	}
+	
+	@ViewBuilder func borderedButtons() -> some View {
+		Section {
+			Text("Bordered Buttons")
+//				.largeTitle(weight: .bold)
+			
+			
+			Text("Enabled Button")
+//				.secondaryTitle(weight: .regular)
+			Button(action: {}) {
+				Text("Click me")
+			}
+			.borderedButton()
+			
+			
+			Text("Disabled Button")
+//				.secondaryTitle(weight: .regular)
+			Button(action: {}) {
+				Text("Click me")
+			}
+			.disabled(true)
+			.borderedButton()
+		}
+	}
+	
+	@ViewBuilder func tintButtons() -> some View {
+		Section {
+			
+			Text("Tertiary Buttons")
+//				.largeTitle(weight: .bold)
+			
+			HStack {
+				Text("Enabled Button")
+//					.secondaryTitle(weight: .regular)
+				Spacer()
+				Button(action: {}) {
+					Text("Click me")
+				}
+				.tertiaryButton()
+			}
+			
+			HStack {
+				Text("Disabled Button")
+//					.secondaryTitle(weight: .regular)
+				Spacer()
+				Button(action: {}) {
+					Text("Click me")
+				}
+				.disabled(true)
+				.tertiaryButton()
+			}
+		}
+	}
+	
+	var body: some View {
+		
+		TabView {
+			List {
+				primaryButtons()
+			}
+			.tabItem {
+				Label("Primary", systemImage: "rectangle.fill")
+			}
+			
+			List {
+				borderedButtons()
+			}
+			.tabItem {
+				Label("Bordered", systemImage: "character.textbox")
+			}
+			
+			List {
+				tintButtons()
+			}
+			.tabItem {
+				Label("Tint", systemImage: "textformat.abc")
+			}
+			
+		}
+		
+		
+	}
+}

--- a/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI/Example-Code/ElementsListView.swift
+++ b/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI/Example-Code/ElementsListView.swift
@@ -1,0 +1,121 @@
+//
+//  ElementsListView.swift
+//  Example-Nitrozen-SwiftUI
+//
+//  Created by Hitendra Solanki on 28/12/22.
+//
+
+import SwiftUI
+import Nitrozen_SwiftUI
+
+struct UIElementTextFieldsView: View {
+	
+	init() {
+		self.setupNitrozenAppearance()
+	}
+	
+	func setupNitrozenAppearance(){
+		
+		let primaryColor = SystemColor.purple
+		let font = SystemFont.title
+		let disabledButtonOpacity: Double = 0.3
+		
+		NitrozenAppearance.shared.colorProvider
+			.primary(primaryColor)
+		
+		NitrozenAppearance.shared.primaryButton
+			.backgroundColor(primaryColor)
+			.backgroundColorDisabled(primaryColor.opacity(disabledButtonOpacity))
+			.titleColor(.white)
+			.titleColorDisabled(.white.opacity(disabledButtonOpacity))
+			.font(font)
+			.borderWidth(0.0)
+		
+		NitrozenAppearance.shared.borderedButton
+			.backgroundColor(.clear)
+			.backgroundColorDisabled(.clear)
+			.titleColor(primaryColor)
+			.titleColorDisabled(primaryColor.opacity(disabledButtonOpacity))
+			.font(font)
+			.borderWidth(1.0)
+		
+		NitrozenAppearance.shared.tertiaryButton
+			.backgroundColor(.clear)
+			.backgroundColorDisabled(.clear)
+			.titleColor(primaryColor)
+			.titleColorDisabled(primaryColor.opacity(disabledButtonOpacity))
+			.font(font)
+			.borderWidth(0.0)
+			
+	}
+	
+	var body: some View {
+		List{
+			
+			Section {
+				
+				Text("Textfields")
+//					.largeTitle(weight: .bold)
+				
+//				Text("Regular Gray border")
+//					.secondaryTitle(weight: .regular)
+//				TextField.init("Placeholder...", text: .constant(""))
+//					.textFieldStyle(UIElement.TextField.Style.NoFocusedBorder())
+//
+//				Text("Focus color border / accent color")
+//					.secondaryTitle(weight: .regular)
+//				TextField.init("Placeholder...", text: .constant(""))
+//					.textFieldStyle(UIElement.TextField.Style.FocusedBorder())
+//
+//
+//				Text("out of focus Error color border ")
+//					.secondaryTitle(weight: .regular)
+//				TextField.init("Placeholder...", text: .constant(""))
+//					.textFieldStyle(UIElement.TextField.Style.NoFocusedErrorBorder())
+//
+//
+//				Text("Focus Error color border")
+//					.secondaryTitle(weight: .regular)
+//				TextField.init("Placeholder...", text: .constant(""))
+//					.textFieldStyle(UIElement.TextField.Style.FocusedErrorBorder())
+			}
+		}
+	}
+}
+
+struct UIElementsList: View {
+	
+	var body: some View {
+		NavigationStack {
+			List {
+				NavigationLink {
+					Buttons()
+				} label: {
+					Text("Buttons")
+				}
+				
+				NavigationLink {
+					UIElementTextFieldsView()
+				} label: {
+					Text("Textfields")
+				}
+				
+				NavigationLink {
+					TextLabels()
+				} label: {
+					Text("TextLabels")
+				}
+
+			}
+			.navigationTitle("Nitrozen Elements")
+		}
+
+	}
+}
+
+struct UIElementsList_Preview: PreviewProvider {
+	static var previews: some View {
+		UIElementsList()
+			.previewDevice(PreviewDevice.init(stringLiteral: "iPhone 14 Pro"))
+	}
+}

--- a/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI/Example-Code/Example_Nitrozen_SwiftUIApp.swift
+++ b/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI/Example-Code/Example_Nitrozen_SwiftUIApp.swift
@@ -1,0 +1,17 @@
+//
+//  Example_Nitrozen_SwiftUIApp.swift
+//  Example-Nitrozen-SwiftUI
+//
+//  Created by Hitendra Solanki on 17/03/23.
+//
+
+import SwiftUI
+
+@main
+struct Example_Nitrozen_SwiftUIApp: App {
+    var body: some Scene {
+        WindowGroup {
+			UIElementsList()
+        }
+    }
+}

--- a/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI/Example-Code/TextLabels.swift
+++ b/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI/Example-Code/TextLabels.swift
@@ -1,0 +1,60 @@
+//
+//  TextLabels.swift
+//  Example-Nitrozen-SwiftUI
+//
+//  Created by Hitendra Solanki on 18/03/23.
+//
+
+import SwiftUI
+import Nitrozen_SwiftUI
+
+struct TextLabels: View {
+	
+	@State var isLoading: Bool = false
+	
+	var body: some View {
+		List{
+			
+			Section {
+				Text("With love, from Jio \n- headingXS")
+					.headingXS()
+				
+				Text("With love, from Jio \n- headingXXS")
+					.headingXXS()
+				
+				Text("With love, from Jio \n- subHeadingS")
+					.subHeadingS()
+				
+				Text("With love, from Jio \n- bodyXS")
+					.bodyXS()
+				
+				Text("With love, from Jio \n- labelXXS")
+					.labelXXS()
+			}
+			
+			Section {
+				
+				HStack{
+					Text("Loading")
+					Toggle("", isOn: $isLoading)
+				}
+				
+				Text("With love, from Jio \n- headingXS")
+					.headingXS(isLoading: $isLoading)
+				
+				Text("With love, from Jio \n- headingXXS")
+					.headingXXS(isLoading: $isLoading)
+				
+				Text("With love, from Jio \n- subHeadingS")
+					.subHeadingS(isLoading: $isLoading)
+				
+				Text("With love, from Jio \n- bodyXS")
+					.bodyXS(isLoading: $isLoading)
+				
+				Text("With love, from Jio \n- labelXXS")
+					.labelXXS(isLoading: $isLoading)
+				
+			}
+		}
+	}
+}

--- a/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Example-Nitrozen-SwiftUI/Example-Nitrozen-SwiftUI/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "activityindicatorview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/exyte/ActivityIndicatorView.git",
+      "state" : {
+        "revision" : "9970fd0bb7a05dad0b6566ae1f56937716686b24",
+        "version" : "1.1.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Nitrozen-SwiftUI",
+	platforms: [
+		.iOS(.v13)
+	],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "Nitrozen-SwiftUI",
+            targets: [
+				"Nitrozen-SwiftUI"
+			]
+		),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+		.package(url: "https://github.com/exyte/ActivityIndicatorView.git", from: .init(1, 1, 1))
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "Nitrozen-SwiftUI",
+			dependencies: [
+				.product(name: "ActivityIndicatorView", package: "ActivityIndicatorView")
+			])
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# nitrozen-ios
+# Nitrozen-SwiftUI
+
+A description of this package.
+

--- a/Sources/Nitrozen-SwiftUI/Appearance/ColorProvider.swift
+++ b/Sources/Nitrozen-SwiftUI/Appearance/ColorProvider.swift
@@ -1,0 +1,32 @@
+//
+//  ColorProvider.swift
+//  Nitrozen-SwiftUI
+//
+//  Created by Hitendra Solanki on 15/03/23.
+//
+
+import SwiftUI
+
+public class ColorProvider {
+	
+	//MARK: public properties
+	public var primary: SystemColor
+	
+	//MARK: Init
+	init(primary: SystemColor) {
+		self.primary = primary
+	}
+}
+
+public extension ColorProvider {
+	//MARK: Public Shared
+	static var shared: ColorProvider = {
+		.init(primary: SystemColor.blue)
+	}()
+}
+
+//MARK: Property updaters
+public extension ColorProvider {
+	@discardableResult
+	func primary(_ primary: SystemColor) -> Self { self.primary = primary; return self }
+}

--- a/Sources/Nitrozen-SwiftUI/Appearance/FontProvider.swift
+++ b/Sources/Nitrozen-SwiftUI/Appearance/FontProvider.swift
@@ -1,0 +1,60 @@
+//
+//  FontProvider.swift
+//  Nitrozen-SwiftUI
+//
+//  Created by Hitendra Solanki on 15/03/23.
+//
+
+import SwiftUI
+
+public class FontProvider {
+	
+	//MARK: public properties
+	public var headingXS: SystemFont
+	public var headingXXS: SystemFont
+	
+	public var subHeadingS: SystemFont
+	public var bodyXS: SystemFont
+	public var labelXXS: SystemFont
+	
+	//MARK: Init
+	init(
+		headingXS: SystemFont, headingXXS: SystemFont,
+		subHeadingS: SystemFont,
+		bodyXS: SystemFont,
+		labelXXS: SystemFont
+	) {
+		self.headingXS = headingXS
+		self.headingXXS = headingXXS
+		self.subHeadingS = subHeadingS
+		self.bodyXS = bodyXS
+		self.labelXXS = labelXXS
+	}
+}
+
+public extension FontProvider {
+	//MARK: Public Shared
+	static var shared: FontProvider = {
+		.init(headingXS: .largeTitle.weight(.bold), headingXXS: .title.weight(.bold),
+			  subHeadingS: .title.weight(.medium), bodyXS: .body.weight(.regular),
+			  labelXXS: .callout.weight(.regular))
+	}()
+}
+
+//MARK: Property updaters
+public extension FontProvider {
+	@discardableResult
+	func headingXS(_ headingXS: SystemFont) -> Self { self.headingXS = headingXS; return self }
+	
+	@discardableResult
+	func headingXXS(_ headingXXS: SystemFont) -> Self { self.headingXXS = headingXXS; return self }
+	
+	@discardableResult
+	func subHeadingS(_ subHeadingS: SystemFont) -> Self { self.subHeadingS = subHeadingS; return self }
+	
+	@discardableResult
+	func bodyXS(_ bodyXS: SystemFont) -> Self { self.bodyXS = bodyXS; return self }
+	
+	@discardableResult
+	func labelXXS(_ labelXXS: SystemFont) -> Self { self.labelXXS = labelXXS; return self }
+}

--- a/Sources/Nitrozen-SwiftUI/Appearance/NitrozenAppearance.swift
+++ b/Sources/Nitrozen-SwiftUI/Appearance/NitrozenAppearance.swift
@@ -1,0 +1,94 @@
+//
+//  Appearance.swift
+//  Nitrozen-SwiftUI
+//
+//  Created by Hitendra Solanki on 14/03/23.
+//
+
+import SwiftUI
+
+public class NitrozenAppearance {
+	
+	init(
+		colorProvider: ColorProvider,
+		fontProvider: FontProvider,
+		
+		primaryButton: NitrozenAppearance.Button,
+		borderedButton: NitrozenAppearance.Button,
+		tertiaryButton: NitrozenAppearance.Button,
+		
+		headingXS: NitrozenAppearance.TextLable,
+		headingXXS: NitrozenAppearance.TextLable,
+		subHeadingS: NitrozenAppearance.TextLable,
+		bodyXS: NitrozenAppearance.TextLable,
+		labelXXS: NitrozenAppearance.TextLable
+	) {
+		self.colorProvider = colorProvider
+		self.fontProvider = fontProvider
+		self.primaryButton = primaryButton
+		self.borderedButton = borderedButton
+		self.tertiaryButton = tertiaryButton
+		
+		self.headingXS = headingXS
+		self.headingXXS = headingXXS
+		self.subHeadingS = subHeadingS
+		self.bodyXS = bodyXS
+		self.labelXXS = labelXXS
+	}
+	
+	//Appearance.public properties
+	public var colorProvider: ColorProvider
+	public var fontProvider: FontProvider
+	
+	//Appearance.Button
+	public var primaryButton: NitrozenAppearance.Button
+	public var borderedButton: NitrozenAppearance.Button
+	public var tertiaryButton: NitrozenAppearance.Button
+	
+	//MARK: public properties
+	public var headingXS: NitrozenAppearance.TextLable
+	public var headingXXS: NitrozenAppearance.TextLable
+	public var subHeadingS: NitrozenAppearance.TextLable
+	public var bodyXS: NitrozenAppearance.TextLable
+	public var labelXXS: NitrozenAppearance.TextLable
+	
+}
+
+public extension NitrozenAppearance {
+	static var shared: NitrozenAppearance = {
+		let colorProvider = ColorProvider.shared
+		let fontProvider = FontProvider.shared
+
+		let disableOpacity: Double = 0.3
+		
+		
+		let font: SystemFont = fontProvider.headingXS
+		
+		return .init(
+			colorProvider: ColorProvider.shared,
+			fontProvider: fontProvider,
+			
+			primaryButton: .init(styleUseCase: .primary,
+								 title: .white, titleDisabled: .white.opacity(disableOpacity),
+								 background: colorProvider.primary, backgroundDisabled: colorProvider.primary.opacity(disableOpacity),
+								 font: font, borderWidth: 0.0),
+			
+			borderedButton: .init(styleUseCase: .bordered,
+								  title: colorProvider.primary, titleDisabled: colorProvider.primary.opacity(disableOpacity),
+								  background: .clear, backgroundDisabled: .clear,
+								  font: font, borderWidth: 1.0),
+			
+			tertiaryButton: .init(styleUseCase: .tertiary,
+								  title: colorProvider.primary, titleDisabled: colorProvider.primary.opacity(disableOpacity),
+								  background: .clear, backgroundDisabled: .clear,
+								  font: font, borderWidth: 1.0),
+			
+			headingXS: .init(titleColor: .black, font: fontProvider.headingXS),
+			headingXXS: .init(titleColor: .black, font: fontProvider.headingXXS),
+			subHeadingS: .init(titleColor: .black, font: fontProvider.subHeadingS),
+			bodyXS: .init(titleColor: .gray, font: fontProvider.bodyXS),
+			labelXXS: .init(titleColor: .gray, font: fontProvider.labelXXS)
+			
+		)
+	}()
+}

--- a/Sources/Nitrozen-SwiftUI/Appearance/View+Shape+Padding.swift
+++ b/Sources/Nitrozen-SwiftUI/Appearance/View+Shape+Padding.swift
@@ -1,0 +1,66 @@
+//
+//  View+Shape+Padding.swift
+//  Nitrozen-SwiftUI
+//
+//  Created by Hitendra Solanki on 18/03/23.
+//
+
+import SwiftUI
+
+public enum ViewShape { case capsule, circle, none }
+
+public enum ViewPadding {
+	
+	///not padding
+	case zero
+	
+	///System default padding -- padding values will  be decided by apple based defference devices/size/deviceSettings
+	case systemDefault
+	
+	///System default padding that can be customized using values to modifiy it
+	/// pass -ve value to decrease the systemDefault padding
+	/// pass +ve value to increase the systemDefault padding
+	case sytemDefaultAddingCustom(paddingToAdd: NSDirectionalEdgeInsets)
+	
+	///custom default padding that can be decided by developer/API caller
+	/// pass -ve value to decrease the existing padding
+	/// pass +ve value to increase the existing padding
+	case custom(paddingToAdd: NSDirectionalEdgeInsets)
+	
+}
+
+extension ViewPadding: Hashable {
+	public func hash(into hasher: inout Hasher) {
+		hasher.combine(self.caseLevelHashValue)
+	}
+	private var caseLevelHashValue: String {
+		switch self {
+		case .zero: return "zero"
+		case .systemDefault: return "systemDefault"
+		case .sytemDefaultAddingCustom: return "sytemDefaultAddingCustom"
+		case .custom: return "custom"
+		}
+	}
+}
+
+extension View {
+	func apply(padding: ViewPadding) -> some View {
+		Group {
+			switch padding {
+			case .zero:
+				self.padding(0)
+			case .systemDefault:
+				self.padding()
+			case .sytemDefaultAddingCustom(let paddingToAdd):
+				self.padding().padding(
+					.init(top: paddingToAdd.top, leading: paddingToAdd.leading, bottom: paddingToAdd.bottom, trailing: paddingToAdd.trailing)
+				)
+			case .custom(let paddingToAdd):
+				self.padding(
+					.init(top: paddingToAdd.top, leading: paddingToAdd.leading, bottom: paddingToAdd.bottom, trailing: paddingToAdd.trailing)
+				)
+			}
+		}
+	}
+}
+

--- a/Sources/Nitrozen-SwiftUI/Elements/Button/Button+Appearance.swift
+++ b/Sources/Nitrozen-SwiftUI/Elements/Button/Button+Appearance.swift
@@ -1,0 +1,58 @@
+//
+//  Button+Appearance.swift
+//  Nitrozen-SwiftUI
+//
+//  Created by Hitendra Solanki on 16/03/23.
+//
+
+import Foundation
+
+public extension NitrozenAppearance {
+	class Button {
+		enum StyleUseCase { case primary, bordered, tertiary, custom }
+		
+		var styleUseCase: StyleUseCase
+		
+		var titleColor: SystemColor
+		var titleColorDisabled: SystemColor
+		var backgroundColor: SystemColor
+		var backgroundColorDisabled: SystemColor
+		var font: SystemFont
+		var borderWidth: Double
+		
+		init(styleUseCase: StyleUseCase,
+			 title: SystemColor, titleDisabled: SystemColor,
+			 background: SystemColor, backgroundDisabled: SystemColor,
+			 font: SystemFont, borderWidth: Double) {
+			
+			self.styleUseCase = styleUseCase
+			self.titleColor = title
+			self.titleColorDisabled = titleDisabled
+			self.backgroundColor = background
+			self.backgroundColorDisabled = backgroundDisabled
+			self.font = font
+			self.borderWidth = borderWidth
+		}
+	}
+}
+
+
+public extension NitrozenAppearance.Button {
+	@discardableResult
+	func titleColor(_ titleColor: SystemColor) -> Self { self.titleColor = titleColor; return self }
+	
+	@discardableResult
+	func titleColorDisabled(_ titleDisabled: SystemColor) -> Self { self.titleColorDisabled = titleDisabled; return self }
+	
+	@discardableResult
+	func backgroundColor(_ background: SystemColor) -> Self { self.backgroundColor = background; return self }
+	
+	@discardableResult
+	func backgroundColorDisabled(_ backgroundDisabled: SystemColor) -> Self { self.backgroundColorDisabled = backgroundDisabled; return self }
+	
+	@discardableResult
+	func font(_ font: SystemFont) -> Self { self.font = font; return self }
+	
+	@discardableResult
+	func borderWidth(_ borderWidth: Double) -> Self { self.borderWidth = borderWidth; return self }
+}

--- a/Sources/Nitrozen-SwiftUI/Elements/Button/Button+ViewHelper.swift
+++ b/Sources/Nitrozen-SwiftUI/Elements/Button/Button+ViewHelper.swift
@@ -1,0 +1,59 @@
+//
+//  Button+ViewHelper.swift
+//  Nitrozen-SwiftUI
+//
+//  Created by Hitendra Solanki on 17/03/23.
+//
+
+import SwiftUI
+
+//MARK: Button Helper -> Public APIs
+public extension View {
+	
+	func primaryButton(isLoading: Binding<Bool> = .constant(false), shape: ViewShape = .capsule) -> some View {
+		var style = nitrozenButtonStyle(forAppearance: NitrozenAppearance.shared.primaryButton, withShape: shape)
+		style.padding(self.buttonPadding(shape: shape))
+		return self.loading(isLoading: isLoading, style: style)
+	}
+	
+	func borderedButton(isLoading: Binding<Bool> = .constant(false), shape: ViewShape = .capsule) -> some View {
+		var style = nitrozenButtonStyle(forAppearance: NitrozenAppearance.shared.borderedButton, withShape: shape)
+		style.padding(self.buttonPadding(shape: shape))
+		return self.loading(isLoading: isLoading, style: style)
+	}
+	
+	func tertiaryButton(isLoading: Binding<Bool> = .constant(false)) -> some View {
+		var style = nitrozenButtonStyle(forAppearance: NitrozenAppearance.shared.tertiaryButton, withShape: .none)
+		style.padding(self.buttonPadding(shape: .none))
+		return self.loading(isLoading: isLoading, style: style)
+	}
+}
+
+fileprivate extension View {
+	func nitrozenButtonStyle(forAppearance: NitrozenAppearance.Button, withShape: ViewShape) -> NitrozenButtonStyle {
+		//padding and loading -> will be decided based on shape and modified later
+		return NitrozenButtonStyle(
+			styleUseCase: forAppearance.styleUseCase,
+			shapeUseCase: withShape,
+			backgroundColor: forAppearance.backgroundColor,
+			backgroundColorDisabled: forAppearance.backgroundColorDisabled,
+			textColor: forAppearance.titleColor,
+			textColorDisabled: forAppearance.titleColorDisabled,
+			font: forAppearance.font,
+			borderWidth: forAppearance.borderWidth,
+			padding: .zero,
+			isLoading: false
+		)
+	}
+	
+	func buttonPadding(shape: ViewShape) -> ViewPadding {
+		switch shape {
+		case .none:
+			return .zero
+		case .circle:
+			return .systemDefault
+		case .capsule:
+			return .sytemDefaultAddingCustom(paddingToAdd: .init(top: -6, leading: 8, bottom: -6, trailing: 8))
+		}
+	}
+}

--- a/Sources/Nitrozen-SwiftUI/Elements/Button/NitrozenButtonStyle.swift
+++ b/Sources/Nitrozen-SwiftUI/Elements/Button/NitrozenButtonStyle.swift
@@ -1,0 +1,187 @@
+//
+//  NitrozenButtonStyle.swift
+//  Nitrozen-SwiftUI
+//
+//  Created by Hitendra Solanki on 16/03/23.
+//
+
+import SwiftUI
+
+extension NitrozenElementLoadingStyle {
+	@discardableResult
+	mutating func isLoading(_ isLoading: Bool) -> Self { self.isLoading = isLoading; return self }
+}
+
+struct NitrozenButtonStyle: ButtonStyle, NitrozenElementStyle, NitrozenElementLoadingStyle {
+	@Environment(\.isEnabled) private var isEnabled
+	
+	private let styleUseCase: NitrozenAppearance.Button.StyleUseCase
+	private let viewShape: ViewShape
+	
+	private let backgroundColor: Color
+	private let backgroundColorDisabled: Color
+	private let textColor: Color
+	private let textColorDisabled: Color
+
+	private let font: Font
+
+	private let radius: CGFloat
+	private let borderWidth: CGFloat
+	
+	private var padding: ViewPadding
+	var isLoading: Bool
+	var loaderSize: NitrozenElementLoaderSize
+
+	init(
+		styleUseCase: NitrozenAppearance.Button.StyleUseCase,
+		shapeUseCase: ViewShape,
+		
+		backgroundColor: Color,
+		backgroundColorDisabled: Color,
+		textColor: Color,
+		textColorDisabled: Color,
+
+		font: Font,
+
+		radius: CGFloat = 0.0,
+		borderWidth: CGFloat = 0.0,
+		padding: ViewPadding,
+		isLoading: Bool = false,
+		loaderSize: NitrozenElementLoaderSize = .defaultSize
+	) {
+		self.styleUseCase = styleUseCase
+		self.viewShape = shapeUseCase
+		self.backgroundColor = backgroundColor
+		self.backgroundColorDisabled = backgroundColorDisabled
+		self.textColor = textColor
+		self.textColorDisabled = textColorDisabled
+		self.font = font
+		self.radius = radius
+		self.borderWidth = borderWidth
+		self.padding = padding
+		self.isLoading = isLoading
+		self.loaderSize = loaderSize
+	}
+
+	func makeBody(configuration: Configuration) -> some View {
+		let forgroundColor = forgroundColor(configuration: configuration)
+		Group {
+			if self.isLoading {
+				ZStack {
+					configuration.label
+						.opacity(0.01)
+					
+					/// This is not final loading indicator
+					/// -- we will replace this With Nitrozen loader later, once we will have loader component ready
+					LoadingIndicatorView(isLoading: self.isLoading, color: forgroundColor)
+						.frame(width: 40, height: 16)
+				}
+			} else {
+				configuration.label
+			}
+		}
+		.font(font)
+		.foregroundColor(forgroundColor)
+		.apply(padding: padding)
+		
+		.background(backgroundView(configuration: configuration))
+		.if(self.viewShape == .capsule, contentTransformer: { view in
+			view
+				.capsuleWithBorder(color: isEnabled ? textColor : textColorDisabled, lineWidth: borderWidth)
+			
+		})
+		.if(self.viewShape == .circle, contentTransformer: { view in
+			view
+				.circleWithBorder(color: isEnabled ? textColor : textColorDisabled, lineWidth: borderWidth)
+		})
+		.if(self.viewShape == .none, contentTransformer: { view in
+			view
+		})
+		
+	}
+}
+
+extension NitrozenButtonStyle {
+	@discardableResult
+	mutating func padding(_ padding: ViewPadding) -> Self { self.padding = padding; return self }
+}
+
+//MARK: Button Background-View
+extension NitrozenButtonStyle {
+	@ViewBuilder private func backgroundView(configuration: Configuration) -> some View {
+		if isEnabled.isFalse {
+			disabledBackground
+		} else if configuration.isPressed {
+			pressedBackground
+		} else {
+			enabledBackground
+		}
+	}
+
+	private var enabledBackground: some View {
+		LinearGradient(
+			colors: [backgroundColor],
+			startPoint: .leading,
+			endPoint: .trailing)
+	}
+
+	private var disabledBackground: some View {
+		LinearGradient(
+			colors: [backgroundColorDisabled],
+			startPoint: .leading,
+			endPoint: .trailing)
+	}
+
+	private var pressedBackground: some View {
+		var backgroundColor = self.backgroundColor
+		if backgroundColor == .clear {
+			switch styleUseCase {
+			case .primary: break //no animation needed
+			case .bordered:
+				backgroundColor = self.textColor //YES animation needed
+			case .tertiary: break //no animation needed
+			case .custom: break
+			}
+		}
+		
+		return LinearGradient(
+			colors: [backgroundColor.opacity(0.7)],
+			startPoint: .leading,
+			endPoint: .trailing)
+		.opacity(0.4)
+	}
+}
+
+//MARK: Button Forground-View
+extension NitrozenButtonStyle {
+	private func forgroundColor(configuration: Configuration) -> Color {
+		if isEnabled.isFalse {
+			return disabledForeground
+		} else if configuration.isPressed {
+			return pressedForeground
+		} else {
+			return enabledForeground
+		}
+	}
+
+	private var enabledForeground: Color {
+		textColor
+	}
+
+	private var disabledForeground: Color {
+		textColorDisabled
+	}
+
+	
+	private var pressedForeground: Color {
+		return textColor.opacity(0.4)
+	}
+}
+
+
+extension View {
+	func apply(buttonStyle: NitrozenButtonStyle) -> some View {
+		self
+			.buttonStyle(buttonStyle)
+	}
+}

--- a/Sources/Nitrozen-SwiftUI/Elements/Element/Modifiers.swift
+++ b/Sources/Nitrozen-SwiftUI/Elements/Element/Modifiers.swift
@@ -1,0 +1,44 @@
+//
+//  File.swift
+//  
+//
+//  Created by Hitendra Solanki on 20/03/23.
+//
+
+import SwiftUI
+
+enum Modifiers {
+	enum Element {}
+	enum Button {}
+}
+
+extension Modifiers.Element {
+	public struct Loading: ViewModifier {
+		@Binding var isLoading: Bool
+		var elementStyle: NitrozenElementLoadingStyle
+		
+		var conditionalLoadingStyle: NitrozenElementLoadingStyle {
+			var loadingStyle = self.elementStyle
+			return loadingStyle.isLoading(isLoading)
+		}
+		
+		init(isLoading: Binding<Bool>, elementStyle: NitrozenElementLoadingStyle) {
+			self._isLoading = isLoading
+			self.elementStyle = elementStyle
+		}
+		
+		@ViewBuilder
+		public func body(content: Content) -> some View {
+			content
+				.apply(elementStyle: conditionalLoadingStyle)
+		}
+	}
+}
+
+
+extension View {
+	
+	func loading(isLoading: Binding<Bool>, style: NitrozenElementLoadingStyle) -> some View {
+		self.modifier(Modifiers.Element.Loading(isLoading: isLoading, elementStyle: style))
+	}
+}

--- a/Sources/Nitrozen-SwiftUI/Elements/Element/NitrozenElementStyle.swift
+++ b/Sources/Nitrozen-SwiftUI/Elements/Element/NitrozenElementStyle.swift
@@ -1,0 +1,38 @@
+//
+//  NitrozenElementStyle.swift
+//  Nitrozen-SwiftUI
+//
+//  Created by Hitendra Solanki on 18/03/23.
+//
+
+import SwiftUI
+
+//base protocol
+protocol NitrozenElementStyle { }
+
+enum NitrozenElementLoaderSize { case defaultSize, custom(size: CGSize) }
+
+/// Any ElementStyle like NitrozenButtonStyle or NitrozenTextStyle that will support loading will confirm this protocol
+/// Future plan: Allow access to loader customization with the help of this protocol -- to support O of SOLID
+protocol NitrozenElementLoadingStyle: NitrozenElementStyle {
+	
+	var isLoading: Bool { get set }
+	var loaderSize: NitrozenElementLoaderSize { get set }
+	
+	@discardableResult
+	mutating func isLoading(_ isLoading: Bool) -> Self
+}
+
+extension View {
+	func apply(elementStyle: NitrozenElementStyle) -> some View {
+		Group {
+			(elementStyle as? NitrozenButtonStyle).convert { style in
+				self.apply(buttonStyle: style)
+			}
+			
+			(elementStyle as? NitrozenTextStyle).convert { style in
+				self.apply(textStyle: style)
+			}
+		}
+	}
+}

--- a/Sources/Nitrozen-SwiftUI/Elements/Text/NitrozenTextStyle.swift
+++ b/Sources/Nitrozen-SwiftUI/Elements/Text/NitrozenTextStyle.swift
@@ -1,0 +1,63 @@
+//
+//  NitrozenTextStyle.swift
+//  Nitrozen-SwiftUI
+//
+//  Created by Hitendra Solanki on 20/03/23.
+//
+
+import SwiftUI
+
+struct NitrozenTextStyle: NitrozenElementStyle, NitrozenElementLoadingStyle {
+
+	let textColor: Color
+	let font: Font
+	
+	var isLoading: Bool
+	var loaderSize: NitrozenElementLoaderSize
+	
+	init(textColor: Color,
+		font: Font,
+		isLoading: Bool,
+		loaderSize: NitrozenElementLoaderSize
+	) {
+		self.textColor = textColor
+		self.font = font
+		self.isLoading = isLoading
+		self.loaderSize = loaderSize
+	}
+}
+
+extension View {
+	func apply(textStyle: NitrozenTextStyle) -> some View {
+		
+		@ViewBuilder func textWithStyle() -> some View {
+			self
+				.font(textStyle.font)
+				.foregroundColor(textStyle.textColor)
+				.opacity(textStyle.isLoading ? 0.001 : 1)
+		}
+		
+		if textStyle.isLoading {
+			return AnyView(GeometryReader { geometryReader in
+				
+				let size: CGSize = {
+					switch textStyle.loaderSize {
+					case .defaultSize:
+						return CGSize(width: geometryReader.size.width, height: geometryReader.size.height)
+					case .custom(let size):
+						return size
+					}
+				}()
+				
+				ZStack(alignment: .topLeading) {
+					textWithStyle()
+					if textStyle.isLoading {
+						ShimmerView(size: size)
+					}
+				}
+			})
+		}
+		
+		return  AnyView(textWithStyle())
+	}
+}

--- a/Sources/Nitrozen-SwiftUI/Elements/Text/Text+Appearance.swift
+++ b/Sources/Nitrozen-SwiftUI/Elements/Text/Text+Appearance.swift
@@ -1,0 +1,20 @@
+//
+//  Text+Appearance.swift
+//  Nitrozen-SwiftUI
+//
+//  Created by Hitendra Solanki on 20/03/23.
+//
+
+import Foundation
+
+public extension NitrozenAppearance {
+	class TextLable {
+		var titleColor: SystemColor
+		var font: SystemFont
+		
+		init(titleColor: SystemColor, font: SystemFont) {
+			self.titleColor = titleColor
+			self.font = font
+		}
+	}
+}

--- a/Sources/Nitrozen-SwiftUI/Elements/Text/Text+ViewHelper.swift
+++ b/Sources/Nitrozen-SwiftUI/Elements/Text/Text+ViewHelper.swift
@@ -1,0 +1,48 @@
+//
+//  Text+ViewHelper.swift
+//  Nitrozen-SwiftUI
+//
+//  Created by Hitendra Solanki on 17/03/23.
+//
+
+import SwiftUI
+
+//MARK: Text Helper -> Public APIs
+public extension View {
+	
+	func headingXS(isLoading: Binding<Bool> = .constant(false)) -> some View {
+		let style = nitrozenTextLabelStyle(forAppearance: NitrozenAppearance.shared.headingXS)
+		return self.loading(isLoading: isLoading, style: style)
+	}
+	
+	func headingXXS(isLoading: Binding<Bool> = .constant(false)) -> some View {
+		let style = nitrozenTextLabelStyle(forAppearance: NitrozenAppearance.shared.headingXXS)
+		return self.loading(isLoading: isLoading, style: style)
+	}
+	
+	func subHeadingS(isLoading: Binding<Bool> = .constant(false)) -> some View {
+		let style = nitrozenTextLabelStyle(forAppearance: NitrozenAppearance.shared.subHeadingS)
+		return self.loading(isLoading: isLoading, style: style)
+	}
+	
+	func bodyXS(isLoading: Binding<Bool> = .constant(false)) -> some View {
+		let style = nitrozenTextLabelStyle(forAppearance: NitrozenAppearance.shared.bodyXS)
+		return self.loading(isLoading: isLoading, style: style)
+	}
+	
+	func labelXXS(isLoading: Binding<Bool> = .constant(false)) -> some View {
+		let style = nitrozenTextLabelStyle(forAppearance: NitrozenAppearance.shared.labelXXS)
+		return self.loading(isLoading: isLoading, style: style)
+	}
+}
+
+fileprivate extension View {
+	func nitrozenTextLabelStyle(forAppearance: NitrozenAppearance.TextLable) -> NitrozenTextStyle {
+		return NitrozenTextStyle(
+			textColor: forAppearance.titleColor,
+			font: forAppearance.font,
+			isLoading: false,
+			loaderSize: .defaultSize
+		)
+	}
+}

--- a/Sources/Nitrozen-SwiftUI/Helper/ActivityIndicator.swift
+++ b/Sources/Nitrozen-SwiftUI/Helper/ActivityIndicator.swift
@@ -1,0 +1,21 @@
+//
+//  File 2.swift
+//  
+//
+//  Created by Hitendra Solanki on 17/03/23.
+//
+
+import ActivityIndicatorView
+import SwiftUI
+
+struct LoadingIndicatorView: View {
+	var isLoading: Bool
+	var color: SystemColor
+	
+	var body: some View {
+		ActivityIndicatorView(
+			isVisible: Binding(get: { isLoading }, set: { let _ = $0 /*no action required*/ }),
+			type: .equalizer(count: 5)
+		)
+	}
+}

--- a/Sources/Nitrozen-SwiftUI/Helper/Bool+Addition.swift
+++ b/Sources/Nitrozen-SwiftUI/Helper/Bool+Addition.swift
@@ -1,0 +1,20 @@
+//
+//  Bool+Addition.swift
+//  FyndPlatform
+//
+//  Created by Hitendra Solanki on 30/11/22.
+//
+
+import Foundation
+
+extension Bool {
+	var invertValue: Bool {
+		return !self
+	}
+	var isTrue: Bool {
+		return self == true
+	}
+	var isFalse: Bool {
+		return self == false
+	}
+}

--- a/Sources/Nitrozen-SwiftUI/Helper/Nitrozen_SwiftUI.swift
+++ b/Sources/Nitrozen-SwiftUI/Helper/Nitrozen_SwiftUI.swift
@@ -1,0 +1,13 @@
+//
+//  Nitrozen_SwiftUI.swift
+//  Nitrozen-SwiftUI
+//
+//  Created by Hitendra Solanki on 16/03/23.
+//
+
+public struct Nitrozen_SwiftUI {
+    public private(set) var text = "Hello, World!"
+
+    public init() {
+    }
+}

--- a/Sources/Nitrozen-SwiftUI/Helper/Optional+Addition.swift
+++ b/Sources/Nitrozen-SwiftUI/Helper/Optional+Addition.swift
@@ -1,0 +1,151 @@
+//
+//  Optional+Addition.swift
+//
+//
+//  Created by Hitendra Solanki on 30/11/22.
+//
+
+import Foundation
+import SwiftUI
+
+extension Optional {
+	
+	var isNil: Bool {
+		guard let _ = self else { return true }
+		return false
+	}
+	var isNotNil: Bool {
+		return !self.isNil
+	}
+}
+
+//MARK: OR operations
+extension Optional {
+	
+	typealias ORScopeReturnValue = Wrapped
+
+	/// Return the value of the Optional or the `default` parameter
+	/// - param: The value to return if the optional is empty
+	func or(_ default: Wrapped) -> ORScopeReturnValue {
+		return self ?? `default`
+	}
+	
+	
+	/// Returns the unwrapped value of the optional *or*
+	/// the result of an expression `else`
+	/// I.e. optional.or(else: print("Arrr"))
+	func or(block: @autoclosure () -> ORScopeReturnValue) -> ORScopeReturnValue {
+		return self ?? block()
+	}
+	
+	/// Returns the unwrapped value of the optional *or*
+	/// the result of calling the closure `else`
+	/// I.e. optional.or(else: {
+	/// ... do a lot of stuff
+	/// })
+	func or(block: () -> ORScopeReturnValue) -> ORScopeReturnValue {
+		return self ?? block()
+	}
+	
+	/// Returns the unwrapped contents of the optional if it is not empty
+	/// If it is empty, throws exception `throw`
+	func or(throw exception: Error) throws -> ORScopeReturnValue {
+		guard let unwrapped = self else { throw exception }
+		return unwrapped
+	}
+	
+}
+
+//MARK: OR operations with optional return to continue chaining
+extension Optional {
+	
+	typealias OROptionalScopeReturnValue = Wrapped?
+	
+	/// Return the value of the Optional or the `default` parameter
+	/// - param: The value to return if the optional is empty
+	func orOptional(_ default: Wrapped) -> OROptionalScopeReturnValue {
+		return self ?? `default`
+	}
+	
+	
+	/// Returns the unwrapped value of the optional *or*
+	/// the result of an expression `else`
+	/// I.e. optional.or(else: print("Arrr"))
+	func orOptional(block: @autoclosure () -> OROptionalScopeReturnValue) -> OROptionalScopeReturnValue {
+		return self ?? block()
+	}
+	
+	/// Returns the unwrapped value of the optional *or*
+	/// the result of calling the closure `else`
+	/// I.e. optional.or(else: {
+	/// ... do a lot of stuff
+	/// })
+	func orOptional(block: () -> OROptionalScopeReturnValue) -> OROptionalScopeReturnValue {
+		return self ?? block()
+	}
+	
+	/// Returns the unwrapped contents of the optional if it is not empty
+	/// If it is empty, throws exception `throw`
+	func orOptional(throw exception: Error) throws -> OROptionalScopeReturnValue {
+		guard let unwrapped = self else { throw exception }
+		return unwrapped
+	}
+	
+}
+
+extension Optional {
+	
+	/// Tries to unwrap `self` and if that succeeds continues to unwrap the parameter `optional`
+	/// and returns the result of that.
+	func and<B>(_ optional: B?) -> B? {
+		guard self != nil else { return nil }
+		return optional
+	}
+	
+	/// Executes a closure with the unwrapped result of an optional.
+	/// This allows chaining optionals together.
+	func convert<T>(block: (Wrapped) -> T?) -> T? {
+		guard let unwrapped = self else { return nil }
+		return block(unwrapped)
+	}
+	
+	func convert<T>(`if`: (Wrapped) -> T, `else`: ()-> T) -> T {
+		guard let unwrapped = self else { return `else`() }
+		return `if`(unwrapped)
+	}
+	
+	/// Only perform `block` if the optional has a non-empty value
+	func perform(block: (Wrapped) -> Void) {
+		guard let unwrapped = self else { return }
+		block(unwrapped)
+	}
+	
+	/// Zips the content of this optional with the content of another
+	/// optional `other` only if both optionals are not empty
+	func zip2<A>(with other: Optional<A>) -> (Wrapped, A)? {
+		guard let first = self, let second = other else { return nil }
+		return (first, second)
+	}
+	
+	/// Zips the content of this optional with the content of another
+	/// optional `other` only if both optionals are not empty
+	func zip3<A, B>(with other: Optional<A>, another: Optional<B>) -> (Wrapped, A, B)? {
+		guard let first = self,
+			  let second = other,
+			  let third = another else { return nil }
+		return (first, second, third)
+	}
+	
+}
+
+extension Optional {
+	/// Executes a closure with the unwrapped result of an optional.
+	/// This allows chaining optionals together.
+	
+	@ViewBuilder
+	func convertToView(@ViewBuilder block: (Wrapped) -> some View) -> some View {
+		if let unwrapped = self {
+			block(unwrapped)
+		}
+	}
+}

--- a/Sources/Nitrozen-SwiftUI/Helper/ShimmerView.swift
+++ b/Sources/Nitrozen-SwiftUI/Helper/ShimmerView.swift
@@ -1,0 +1,86 @@
+//
+//  ShimmerView.swift
+//  FyndPlatform
+//
+//  Created by Hitendra Solanki on 11/03/23.
+//
+
+import SwiftUI
+
+//TODO: Hitendra - This is just copy from web for now, make it reusable with Configuration and Solid Standard
+
+struct ShimmerView: View {
+	@State private var isAnimating: Bool
+	private let offset: CGFloat
+	private let rotationAngle: Angle
+	private let linearGradient: LinearGradient
+	private let animation: Animation
+	private let primaryColor: Color
+	private let shimmerColor: Color
+	private let size: CGSize
+	private let shimmerSize: CGSize
+	private let cornerRadius: CGFloat
+	
+	init(rotationAngle: Angle = Angle(degrees: 70),
+		 animationSpeed: CGFloat = 0.2,
+		 primaryColor: Color = .black.opacity(0.2),
+		 shimmerColor: Color = .white.opacity(0.6),
+		 size: CGSize = CGSize(width: 350, height: 200),
+		 cornerRadius: CGFloat = 10) {
+		self.offset = size.width * 1.5
+		self.isAnimating = true
+		self.rotationAngle = rotationAngle
+		self.linearGradient = LinearGradient(colors: [shimmerColor.opacity(0.1),
+													  shimmerColor,
+													  shimmerColor.opacity(0.1)],
+											 startPoint: .top,
+											 endPoint: .bottom)
+		self.animation = Animation.default.speed(animationSpeed).delay(0).repeatForever(autoreverses: false)
+		self.primaryColor = primaryColor
+		self.shimmerColor = shimmerColor
+		self.size = size
+		self.shimmerSize = CGSize(width: size.width * 1.5,
+								  height: size.width * 1.5)
+		self.cornerRadius = cornerRadius
+	}
+	
+	var body: some View {
+		primaryColor
+			.frame(width: size.width, height: size.height)
+			.overlay(shimmerLayer())
+			.cornerRadius(cornerRadius)
+			.onAppear {
+				withAnimation(animation) {
+					isAnimating.toggle()
+				}
+			}
+	}
+	
+	private func shimmerLayer() -> some View {
+		return Rectangle()
+			.fill(linearGradient)
+			.frame(width: shimmerSize.width,
+				   height: shimmerSize.height)
+			.rotationEffect(rotationAngle)
+			.offset(x: isAnimating ? offset : -offset)
+	}
+}
+
+struct ShimmerView_Previews: PreviewProvider {
+	static var previews: some View {
+		VStack {
+			HStack {
+				ShimmerView(size: CGSize(width: 60, height: 60))
+				VStack(alignment: .leading) {
+					ShimmerView(size: CGSize(width: 180, height: 13))
+					ShimmerView(size: CGSize(width: 120, height: 13))
+					ShimmerView(size: CGSize(width: 60, height: 13))
+				}
+			}
+			
+			ShimmerView()
+		}
+		.padding()
+		.previewLayout(.sizeThatFits)
+	}
+}

--- a/Sources/Nitrozen-SwiftUI/Helper/View+ClipShapes.swift
+++ b/Sources/Nitrozen-SwiftUI/Helper/View+ClipShapes.swift
@@ -1,0 +1,60 @@
+//
+//  View+ClipShapes.swift
+//  
+//
+//  Created by Hitendra Solanki on 17/03/23.
+//
+
+import SwiftUI
+
+extension View {
+	
+	func roundedCornerWithBorder(color: Color, radius: CGFloat = 10, lineWidth: CGFloat = 0.0) -> some View {
+		self
+			.overlay(content: {
+				RoundedRectangle(cornerRadius: radius, style: .continuous)
+					.stroke(color, lineWidth: lineWidth)
+			})
+			.clipShape(
+				RoundedRectangle(cornerRadius: radius, style: .continuous)
+			)
+	}
+	
+	func capsuleWithBorder(color: Color, lineWidth: CGFloat = 0.0) -> some View {
+		self
+			.overlay(content: {
+				Capsule(style: .continuous)
+					.stroke(color, lineWidth: lineWidth)
+			})
+			.clipShape(
+				Capsule(style: .continuous)
+			)
+	}
+	
+	func circleWithBorder(color: Color, lineWidth: CGFloat = 0.0) -> some View {
+		self
+			.overlay(content: {
+				Circle()
+					.stroke(color, lineWidth: lineWidth)
+			})
+			.clipShape(
+				Circle()
+			)
+	}
+}
+
+extension View {
+	func background<T: View>(
+		alignment: Alignment = .center,
+		@ViewBuilder content: () -> T
+	) -> some View {
+		background(Group(content: content), alignment: alignment)
+	}
+
+	func overlay<T: View>(
+		alignment: Alignment = .center,
+		@ViewBuilder content: () -> T
+	) -> some View {
+		overlay(Group(content: content), alignment: alignment)
+	}
+}

--- a/Sources/Nitrozen-SwiftUI/Helper/View+Conditional.swift
+++ b/Sources/Nitrozen-SwiftUI/Helper/View+Conditional.swift
@@ -1,0 +1,23 @@
+//
+//  View+Conditional.swift
+//  
+//
+//  Created by Hitendra Solanki on 17/03/23.
+//
+
+import SwiftUI
+
+extension View {
+	/// Applies the given transform if the given condition evaluates to `true`.
+	/// - Parameters:
+	///   - condition: The condition to evaluate.
+	///   - contentTransformer: The transform to apply to the source `View`.
+	/// - Returns: Either the original `View` or the modified `View` if the condition is `true`.
+	@ViewBuilder func `if`<Content: View>(_ condition: Bool, contentTransformer: (Self) -> Content) -> some View {
+		if condition {
+			contentTransformer(self)
+		} else {
+			self
+		}
+	}
+}

--- a/Sources/Nitrozen-SwiftUI/Typealias.swift
+++ b/Sources/Nitrozen-SwiftUI/Typealias.swift
@@ -1,0 +1,15 @@
+//
+//  Typealias.swift
+//  Nitrozen-SwiftUI
+//
+//  Created by Hitendra Solanki on 14/03/23.
+//
+
+import Foundation
+import SwiftUI
+
+public typealias SystemColor = SwiftUI.Color
+public typealias SystemFont = SwiftUI.Font
+
+
+

--- a/Tests/Nitrozen-SwiftUITests/Nitrozen_SwiftUITests.swift
+++ b/Tests/Nitrozen-SwiftUITests/Nitrozen_SwiftUITests.swift
@@ -1,0 +1,18 @@
+//
+//  Nitrozen_SwiftUITests.swift
+//  Nitrozen-SwiftUI
+//
+//  Created by Hitendra Solanki on 16/03/23.
+//
+
+import XCTest
+@testable import Nitrozen_SwiftUI
+
+final class Nitrozen_SwiftUITests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+        XCTAssertEqual(Nitrozen_SwiftUI().text, "Hello, World!")
+    }
+}


### PR DESCRIPTION
- Highly customisable Appearance as per iOS API standards
- Highly customisable button layout with Nitrozen SwiftUI button style guidelines
- Highly customisable Text/Label layout with Nitrozen Text style
- Button Styling single lineAPI for primary, bordered and tertiary button customization
- Button and TextLabel both are customizable using modifiers as per SwiftUI style guidelines
- Example project how to use our nitrozen elements


P.S. I will add documentation later -- for now team can start using Button and Text/Label as per example project with line API